### PR TITLE
Add brand-models lookup app for air purifier filters

### DIFF
--- a/app/apps/[slug]/page.tsx
+++ b/app/apps/[slug]/page.tsx
@@ -2,9 +2,11 @@ import { getAppBySlug } from "@/lib/registry";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import AsinKeywordsApp from "@/apps/asin-keywords/App";
+import BrandModelsApp from "@/apps/brand-models/App";
 
 const appComponents: Record<string, React.ComponentType> = {
   "asin-keywords": AsinKeywordsApp,
+  "brand-models": BrandModelsApp,
 };
 
 export default async function AppPage({

--- a/apps/brand-models/App.tsx
+++ b/apps/brand-models/App.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useState } from "react";
+
+interface ApiResponse {
+  [key: string]: unknown;
+}
+
+interface BrandModelResult {
+  brand: string;
+  filters: Array<{
+    asin: string;
+    title: string;
+    compatibleModels: string[];
+  }>;
+  hostModels: Array<{
+    model: string;
+    details: Record<string, unknown>;
+  }>;
+  tableData: Record<string, unknown>;
+}
+
+export default function BrandModelsApp() {
+  const [brand, setBrand] = useState("");
+  const [market, setMarket] = useState("US");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [result, setResult] = useState<BrandModelResult | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setResult(null);
+
+    if (!brand.trim()) {
+      setError("请输入品牌名称");
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      const response = await fetch("/api/n8n/trigger", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          workflow: "brand-models-lookup",
+          payload: {
+            brand: brand.trim(),
+            category: "空气净化器滤芯",
+            market: market,
+          },
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || "请求失败");
+      }
+
+      const data = await response.json();
+      setResult(data);
+    } catch (err) {
+      setError((err as Error).message || "发生错误");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="bg-blue-50 border border-blue-200 rounded-md p-4">
+        <h3 className="font-semibold text-blue-900 mb-2">功能说明</h3>
+        <ul className="text-sm text-blue-800 space-y-1">
+          <li>• 根据品牌查询空气净化器滤芯</li>
+          <li>• 提取滤芯适配的主机型号</li>
+          <li>• 验证适配关系</li>
+          <li>• 查询相关12张数据表的信息</li>
+        </ul>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label
+            htmlFor="brand"
+            className="block text-sm font-medium text-gray-700 mb-2"
+          >
+            品牌名称
+          </label>
+          <input
+            id="brand"
+            type="text"
+            value={brand}
+            onChange={(e) => setBrand(e.target.value)}
+            placeholder="例如: Levoit, Shark, Coway"
+            className="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            disabled={loading}
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="market"
+            className="block text-sm font-medium text-gray-700 mb-2"
+          >
+            市场
+          </label>
+          <select
+            id="market"
+            value={market}
+            onChange={(e) => setMarket(e.target.value)}
+            className="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            disabled={loading}
+          >
+            <option value="US">美国 (US)</option>
+            <option value="CA">加拿大 (CA)</option>
+            <option value="UK">英国 (UK)</option>
+          </select>
+        </div>
+
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full py-2 px-4 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 text-white font-medium rounded-md transition-colors"
+        >
+          {loading ? "查询中..." : "开始查询"}
+        </button>
+      </form>
+
+      {error && (
+        <div className="p-4 bg-red-50 border border-red-200 rounded-md">
+          <p className="text-red-800 text-sm">{error}</p>
+        </div>
+      )}
+
+      {result && (
+        <div className="space-y-4">
+          <h3 className="text-lg font-semibold text-gray-900">查询结果</h3>
+
+          {/* Filters Section */}
+          {result.filters && result.filters.length > 0 && (
+            <div className="bg-gray-50 rounded-md p-4">
+              <h4 className="font-semibold text-gray-800 mb-3">
+                滤芯列表 ({result.filters.length})
+              </h4>
+              <div className="space-y-3">
+                {result.filters.map((filter, idx) => (
+                  <div
+                    key={idx}
+                    className="bg-white p-3 rounded border border-gray-200"
+                  >
+                    <p className="text-sm font-medium text-gray-900">
+                      {filter.title}
+                    </p>
+                    <p className="text-xs text-gray-600 mt-1">
+                      ASIN: {filter.asin}
+                    </p>
+                    {filter.compatibleModels &&
+                      filter.compatibleModels.length > 0 && (
+                        <div className="mt-2">
+                          <p className="text-xs font-medium text-gray-700">
+                            适配型号:
+                          </p>
+                          <p className="text-xs text-gray-600">
+                            {filter.compatibleModels.join(", ")}
+                          </p>
+                        </div>
+                      )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Host Models Section */}
+          {result.hostModels && result.hostModels.length > 0 && (
+            <div className="bg-gray-50 rounded-md p-4">
+              <h4 className="font-semibold text-gray-800 mb-3">
+                主机型号 ({result.hostModels.length})
+              </h4>
+              <div className="space-y-2">
+                {result.hostModels.map((model, idx) => (
+                  <div
+                    key={idx}
+                    className="bg-white p-3 rounded border border-gray-200"
+                  >
+                    <p className="text-sm font-medium text-gray-900">
+                      {model.model}
+                    </p>
+                    {Object.keys(model.details).length > 0 && (
+                      <pre className="text-xs text-gray-600 mt-2 overflow-auto">
+                        {JSON.stringify(model.details, null, 2)}
+                      </pre>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Raw Data Section */}
+          <div className="bg-gray-50 rounded-md p-4">
+            <h4 className="font-semibold text-gray-800 mb-3">完整数据</h4>
+            <div className="overflow-auto max-h-96">
+              <pre className="text-xs text-gray-800">
+                {JSON.stringify(result, null, 2)}
+              </pre>
+            </div>
+          </div>
+
+          {/* Export Button */}
+          <button
+            onClick={() => {
+              const blob = new Blob([JSON.stringify(result, null, 2)], {
+                type: "application/json",
+              });
+              const url = URL.createObjectURL(blob);
+              const a = document.createElement("a");
+              a.href = url;
+              a.download = `${brand}-${market}-results.json`;
+              a.click();
+              URL.revokeObjectURL(url);
+            }}
+            className="w-full py-2 px-4 bg-green-600 hover:bg-green-700 text-white font-medium rounded-md transition-colors"
+          >
+            导出结果为 JSON
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/brand-models/README.md
+++ b/apps/brand-models/README.md
@@ -1,0 +1,146 @@
+# 品牌主机型号查询应用
+
+## 功能描述
+
+根据空气净化器品牌查询该品牌下的所有滤芯，并反查该品牌的所有主机型号及其适配关系。
+
+## 输入参数
+
+- **品牌** (brand): 空气净化器品牌名称，如 Levoit、Shark、Coway 等
+- **类目** (category): 固定为"空气净化器滤芯"
+- **市场** (market): 可选 US（美国）、CA（加拿大）、UK（英国）
+
+## n8n 工作流集成
+
+### 工作流名称
+`brand-models-lookup`
+
+### Payload 格式
+```json
+{
+  "brand": "Levoit",
+  "category": "空气净化器滤芯",
+  "market": "US"
+}
+```
+
+### 预期响应格式
+```json
+{
+  "brand": "Levoit",
+  "filters": [
+    {
+      "asin": "B08N5WRWNW",
+      "title": "Levoit Air Purifier Replacement Filter",
+      "compatibleModels": ["Core 300", "Core 300S", "Core P350"]
+    }
+  ],
+  "hostModels": [
+    {
+      "model": "Core 300",
+      "details": {
+        "sku": "CORE300-WH",
+        "releaseDate": "2020-01-01",
+        "specifications": {}
+      }
+    }
+  ],
+  "tableData": {
+    "配件SKU主数据": [...],
+    "主机型号库": [...],
+    "适配关系表": [...],
+    "竞品ASIN库": [...],
+    "关键词主库": [...],
+    "关键词-适配关系": [...]
+  }
+}
+```
+
+## n8n 工作流设计
+
+### 所需节点
+
+1. **Webhook 触发节点**
+   - 接收来自 `/api/n8n/trigger` 的请求
+   - 解析 workflow 和 payload
+
+2. **DataForSEO API 节点**
+   - 根据品牌和类目查询相关滤芯 ASIN
+   - API: Product Search / SERP API
+
+3. **Keepa API 节点**
+   - 批量查询 ASIN 详情
+   - 获取产品标题、描述、适配信息等
+
+4. **Gemini/Claude API 节点 - 提取型号**
+   - 使用 AI 从产品描述中提取适配主机型号
+   - Prompt: "Extract all compatible air purifier model numbers from this product description: {description}"
+
+5. **Google Sheets API 节点 - 查询**
+   - 查询 12 张数据表：
+     - 配件SKU主数据
+     - 主机型号库
+     - 适配关系表
+     - 竞品ASIN库
+     - 关键词主库
+     - 关键词-适配关系
+     - 其他 6 张相关表格
+
+6. **Gemini/Claude API 节点 - 验证**
+   - 验证提取的主机型号是否属于该品牌
+   - 交叉验证适配关系的准确性
+
+7. **Google Sheets API 节点 - 写入**
+   - 将查询结果写入 Google Sheets
+   - 包括品牌、滤芯、主机型号、验证状态、证据链接等
+
+8. **响应节点**
+   - 格式化结果并返回给前端
+
+### 环境变量配置
+
+在 n8n 中配置以下凭据：
+- DataForSEO API 凭据
+- Keepa API 密钥
+- Google Cloud API 凭据（用于 Gemini API）
+- Anthropic API 密钥（用于 Claude API）
+- Google Sheets API 凭据
+
+### 数据流程
+
+```
+1. 接收请求 (品牌 + 市场)
+   ↓
+2. DataForSEO 查询滤芯 ASIN
+   ↓
+3. Keepa 获取 ASIN 详情
+   ↓
+4. AI 提取适配主机型号
+   ↓
+5. Google Sheets 查询 12 张表
+   ↓
+6. AI 验证适配关系
+   ↓
+7. 整合所有数据
+   ↓
+8. (可选) 写入 Google Sheets
+   ↓
+9. 返回结果
+```
+
+## 使用说明
+
+1. 确保 n8n 工作流已配置并运行
+2. 在 `.env` 中配置 `N8N_WEBHOOK_URL`
+3. (可选) 配置 `N8N_WEBHOOK_SECRET` 以保护 webhook
+4. 访问应用页面 `/apps/brand-models`
+5. 输入品牌名称和市场
+6. 点击"开始查询"
+7. 查看结果并可导出为 JSON
+
+## 注意事项
+
+- 所有 API 密钥都配置在 n8n 中，不会暴露到前端
+- 查询可能需要较长时间，因为涉及多个 API 调用和数据表查询
+- 建议在 n8n 中添加错误处理和重试逻辑
+- 可以添加缓存机制以加速重复查询

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -12,6 +12,12 @@ export const allApps: AppInfo[] = [
     category: "亚马逊工具",
     description: "输入ASIN获取关键词分析",
   },
+  {
+    slug: "brand-models",
+    title: "品牌主机型号查询",
+    category: "产品分析工具",
+    description: "根据空气净化器品牌查询滤芯及主机型号适配关系",
+  },
 ];
 
 export function getAppBySlug(slug: string): AppInfo | undefined {


### PR DESCRIPTION
Add new mini-app for querying air purifier filters and host models by brand.

### Changes
- Created new mini-app at `apps/brand-models/App.tsx`
- Added brand-models to app registry under new "产品分析工具" category
- Integrated with n8n workflow for DataForSEO, Keepa, Gemini/Claude APIs
- Added comprehensive README with n8n workflow design
- Supports querying filters by brand and reverse-lookup of host models
- Displays results from 12 data tables with export functionality

Fixes #5

Generated with [Claude Code](https://claude.ai/code)